### PR TITLE
Fix bootstrap weight random seed and shrink data type

### DIFF
--- a/python/modules/qcdBootstrapProducer.py
+++ b/python/modules/qcdBootstrapProducer.py
@@ -31,8 +31,10 @@ class qcdBootstrapProducer(Module):
 
     
     def analyze(self, event):
-	#Need to initialize a random seed
-	ROOT.gRandom.SetSeed(123456)
+        # Need to initialize a random seed.  Use the event number so that we
+        # have a different seed for every event, but we will get the same
+        # smearing each time if we run multiple times.
+        ROOT.gRandom.SetSeed(event.event)
 
 	b = []        
 	for iB in xrange(self.nBootstraps) :

--- a/python/modules/qcdBootstrapProducer.py
+++ b/python/modules/qcdBootstrapProducer.py
@@ -26,8 +26,8 @@ class qcdBootstrapProducer(Module):
 
     def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
 	self.out = wrappedOutputTree
-	self.out.branch("nBootstrapWeight",        "I")
-	self.out.branch("bootstrapWeight",         "I", lenVar="nBootstrapWeight")
+	self.out.branch("nBootstrapWeight",        "B")
+	self.out.branch("bootstrapWeight",         "B", lenVar="nBootstrapWeight")
 
     
     def analyze(self, event):

--- a/python/modules/qcdSmearProducer.py
+++ b/python/modules/qcdSmearProducer.py
@@ -47,8 +47,8 @@ class qcdSmearProducer(Module):
     def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree, outputFileSmear, outputTreeSmear):
         self.out = wrappedOutputTree
         self.outsmear = outputTreeSmear
-        self.out.branch("nBootstrapWeight",        "I")
-        self.out.branch("bootstrapWeight",         "I", lenVar="nBootstrapWeight")
+        self.out.branch("nBootstrapWeight",        "B")
+        self.out.branch("bootstrapWeight",         "B", lenVar="nBootstrapWeight")
         self.out.branch("uniqueID", "l")
         self.outsmear.branch("Jet_pt", "F", lenVar="nJet")
         self.outsmear.branch("Jet_eta", "F", lenVar="nJet")
@@ -60,8 +60,8 @@ class qcdSmearProducer(Module):
         self.outsmear.branch("Stop0l_evtWeight", "F")
         self.outsmear.branch("Stop0l_smearWeight", "F")
         self.outsmear.branch("uniqueID", "l")
-        self.outsmear.branch("nBootstrapWeight",        "I")
-        self.outsmear.branch("bootstrapWeight",         "I", lenVar="nBootstrapWeight")
+        self.outsmear.branch("nBootstrapWeight",        "B")
+        self.outsmear.branch("bootstrapWeight",         "B", lenVar="nBootstrapWeight")
         self.targeth = self.loadHisto(self.respFileName,self.respHistName)
 
     def ptmapping(self, recojet, vecKind):


### PR DESCRIPTION
This fixes the random seed used to create the bootstrap weights in post-processing.  It also shrinks the data type used to store the bootstrap weights from a 32-bit integer to an 8-bit integer.